### PR TITLE
Run PlugInstall in installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ ln -s $current_path/tmux.conf ~/.tmux.conf
 touch ~/.vimrc.bundles.local
 
 vim +PluginInstall +qall
+vim +PlugInstall +qall
 
 echo "Making neovim read vim config..."
 mkdir -p ~/.config/nvim


### PR DESCRIPTION
We use Plug for `coc.nvim`. Need to run `PlugInstall` during set up as well.