### PR TITLE
Fix snipmate warning

### DIFF
--- a/vimrc.local
+++ b/vimrc.local
@@ -47,3 +47,5 @@ let g:CommandTFileScanner = 'watchman'
 
 vnoremap // y/<C-R>"<CR>
 
+" Fix warning everytime vim is started
+let g:snipMate = { 'snippet_version' : 1 }


### PR DESCRIPTION
Following this: https://www.wiserfirst.com/blog/vim-tip-snipmate-legacy-parser-warning/